### PR TITLE
Use Arc instead of Rc to allow use in async libs like skynet-rs

### DIFF
--- a/src/http.rs
+++ b/src/http.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::fmt;
 use std::rc::Rc;
+use std::sync::Arc;
 
 /// An alias for `HashMap<String, String>`, which represents a set of HTTP headers and their values.
 pub type Headers = HashMap<String, String>;
@@ -38,7 +39,7 @@ pub struct HttpResponse {
 }
 
 /// The required trait used by `tus_async_client::Client` to represent a handler to execute `HttpRequest`s.
-pub struct HttpHandler(pub(crate) Rc<reqwest::Client>);
+pub struct HttpHandler(pub(crate) Arc<reqwest::Client>);
 
 /// Returns the default headers required to make requests to an tus enabled endpoint.
 pub fn default_headers() -> Headers {

--- a/src/http_handler.rs
+++ b/src/http_handler.rs
@@ -4,10 +4,11 @@ use reqwest::header::{HeaderMap, HeaderName};
 use reqwest::Method;
 use std::collections::HashMap;
 use std::str::FromStr;
-use std::rc::Rc;
+use std::rc::{Rc};
+use std::sync::Arc;
 
 impl HttpHandler {
-    pub fn new(client: Rc<reqwest::Client>) -> Self {
+    pub fn new(client: Arc<reqwest::Client>) -> Self {
         Self(client)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,10 +8,11 @@
 //! use tus_async_client::Client;
 //! use reqwest;
 //! use std::rc::Rc;
+//! use std::sync::Arc;
 //!
 //! // Create an instance of the `tus_async_client::Client` struct.
 //! // Assumes "reqwest" feature is enabled (see above)
-//! let client = Client::new(Rc::new(reqwest::Client::new()));
+//! let client = Client::new(Arc::new(reqwest::Client::new()));
 //!
 //! // You'll need an upload URL to be able to upload a files.
 //! // This may be provided to you (through a separate API, for example),
@@ -451,3 +452,4 @@ fn create_upload_headers(progress: usize) -> Headers {
     headers.insert(headers::UPLOAD_OFFSET.to_owned(), progress.to_string());
     headers
 }
+


### PR DESCRIPTION
I'm using tus_async_upload inside skynet-rs, inside a crate that supports uploading git LFS objects to decentralized storage. The use of Rc however disabled support of the Send kind, preventing me from using the TUS client in async event loops. 